### PR TITLE
fix: remove hardcoded API token from SimulationsManager

### DIFF
--- a/fluidize/managers/simulations.py
+++ b/fluidize/managers/simulations.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from fluidize_sdk import FluidizeSDK
 
+from fluidize.config import config
 from fluidize.core.types.node import nodeMetadata_simulation
 
 
@@ -16,8 +17,22 @@ class SimulationsManager:
             adapter: adapter (FluidizeSDK or LocalAdapter)
         """
         self._adapter = adapter
-        # TODO: Fix hardcoding of api_token and remove type ignore
-        self.fluidize_sdk = FluidizeSDK(api_token="placeholder")  # noqa: S106
+
+        # Use the adapter if it's already a FluidizeSDK instance, otherwise create one
+        if (
+            hasattr(adapter, "api_token")
+            and hasattr(adapter, "simulation")
+            and adapter.api_token is not None
+            and adapter.simulation is not None
+        ):
+            # Assume it's already a FluidizeSDK instance
+            self.fluidize_sdk = adapter
+        else:
+            # Create FluidizeSDK with proper API key from config
+            if not config.api_key:
+                msg = "API key is required. Set the FLUIDIZE_API_KEY environment variable."
+                raise ValueError(msg)
+            self.fluidize_sdk = FluidizeSDK(api_token=config.api_key)
 
     def list_simulations(self) -> list[Any]:
         """

--- a/tests/integration/test_simulations_manager.py
+++ b/tests/integration/test_simulations_manager.py
@@ -1,5 +1,8 @@
 """Integration tests for SimulationsManager - tests real API connectivity."""
 
+import os
+from unittest.mock import Mock, patch
+
 import pytest
 
 from fluidize.managers.simulations import SimulationsManager
@@ -11,11 +14,10 @@ class TestSimulationsManagerIntegration:
     @pytest.fixture
     def mock_adapter(self):
         """Create a mock adapter for testing."""
-        from unittest.mock import Mock
-
         adapter = Mock()
         return adapter
 
+    @pytest.mark.skipif(not os.getenv("FLUIDIZE_API_KEY"), reason="FLUIDIZE_API_KEY environment variable not set")
     def test_list_simulations_integration(self, mock_adapter):
         """Integration test that actually calls the API and prints output."""
 
@@ -38,3 +40,15 @@ class TestSimulationsManagerIntegration:
             print(f"  Description: {sim.description}")
             print(f"  Version: {sim.version}")
             print("\n")
+
+    def test_list_simulations_without_api_key(self, mock_adapter):
+        """Test behavior when no API key is available."""
+        # Ensure mock_adapter doesn't have SDK attributes so new SDK creation is attempted
+        mock_adapter.api_token = None
+        mock_adapter.simulation = None
+
+        with patch("fluidize.managers.simulations.config") as mock_config:
+            mock_config.api_key = None
+
+            with pytest.raises(ValueError, match="API key is required"):
+                SimulationsManager(mock_adapter)


### PR DESCRIPTION
- Use API key from environment variable FLUIDIZE_API_KEY
- Support passing FluidizeSDK as adapter directly
- Add proper error handling for missing API key
- Update tests to handle new configuration logic